### PR TITLE
Add bottom navbar with icons

### DIFF
--- a/components/BottomNav.vue
+++ b/components/BottomNav.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow flex justify-around items-center py-3 z-10">
+      <NuxtLink to="/" class="flex flex-col items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75" />
+        </svg>
+      </NuxtLink>
+      <NuxtLink to="/annonces" class="flex flex-col items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+        </svg>
+      </NuxtLink>
+      <NuxtLink to="/search" class="-mt-8 bg-[#39FF14] p-3 rounded-full shadow-lg">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-white">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 103.404 3.404a7.5 7.5 0 0012.399 12.399z" />
+        </svg>
+      </NuxtLink>
+      <button @click="toggle" class="flex flex-col items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+        </svg>
+      </button>
+      <NuxtLink to="/profile" class="flex flex-col items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 1115 0v.75H4.5v-.75z" />
+        </svg>
+      </NuxtLink>
+    </nav>
+    <div v-if="open" class="fixed inset-0 z-0" @click="open = false"></div>
+    <div v-if="open" class="absolute bottom-20 right-4 bg-white border rounded shadow-md p-4 z-20">
+      <ul class="space-y-2">
+        <li>
+          <NuxtLink to="/favorites" class="block">Mes favoris</NuxtLink>
+        </li>
+        <li>
+          <NuxtLink to="/reservations" class="block">Mes reservations</NuxtLink>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const open = ref(false)
+function toggle() {
+  open.value = !open.value
+}
+</script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="pb-16">
+    <slot />
+    <BottomNav />
+  </div>
+</template>
+
+<script setup>
+// Nothing here for now
+</script>

--- a/pages/favorites.vue
+++ b/pages/favorites.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold">Mes favoris</h1>
+  </div>
+</template>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold">Modification du profil</h1>
+  </div>
+</template>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold">Page de recherche</h1>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- create a default layout
- implement `BottomNav` component with home, add, search, burger and profile icons
- add placeholder pages for search, profile and favorites

## Testing
- `npx --yes eslint .` *(fails: Cannot find package 'eslint-config-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_68485d213b5c8331ba9d5aa0bde0f36d