### PR TITLE
Implement horizontal scroller for home page

### DIFF
--- a/components/HorizontalScroller.vue
+++ b/components/HorizontalScroller.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="relative w-full">
+    <button v-if="showArrows" @click="scrollLeft" class="absolute left-0 top-1/2 -translate-y-1/2 z-10 p-2 bg-white rounded-full shadow">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+      </svg>
+    </button>
+    <div ref="container" class="flex space-x-4 overflow-x-auto pb-4 w-full scrollbar-hide scroll-smooth">
+      <slot />
+    </div>
+    <button v-if="showArrows" @click="scrollRight" class="absolute right-0 top-1/2 -translate-y-1/2 z-10 p-2 bg-white rounded-full shadow">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+const container = ref(null)
+const showArrows = ref(false)
+
+function update() {
+  if (container.value) {
+    showArrows.value = container.value.scrollWidth > container.value.clientWidth
+  }
+}
+
+function scrollLeft() {
+  if (container.value) container.value.scrollBy({ left: -container.value.clientWidth, behavior: 'smooth' })
+}
+
+function scrollRight() {
+  if (container.value) container.value.scrollBy({ left: container.value.clientWidth, behavior: 'smooth' })
+}
+
+onMounted(() => {
+  update()
+  window.addEventListener('resize', update)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', update)
+})
+</script>
+
+<style scoped>
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,9 @@
 <!-- pages/index.vue -->
 <template>
   <div class="min-h-screen bg-gray-50">
-    <section class="px-4 mt-8" v-if="savedOffers.length">
-      <h2 class="text-2xl font-semibold mb-4">Vos offres sauvegardées</h2>
-      <div class="flex space-x-4 overflow-x-auto pb-4">
+    <section class="mt-8 w-full" v-if="savedOffers.length">
+      <h2 class="text-2xl font-semibold mb-4 px-4">Vos offres sauvegardées</h2>
+      <HorizontalScroller>
         <div v-for="offer in savedOffers" :key="offer.id" class="bg-white rounded shadow w-40 flex-shrink-0">
           <img :src="offer.image" class="h-24 w-full object-cover rounded-t" />
           <div class="p-2">
@@ -11,12 +11,12 @@
             <p class="text-xs text-gray-500">{{ offer.price }}</p>
           </div>
         </div>
-      </div>
+      </HorizontalScroller>
     </section>
 
-    <section class="px-4 mt-8" v-if="furnitureOffers.length">
-      <h2 class="text-2xl font-semibold mb-4">Mobilier</h2>
-      <div class="flex space-x-4 overflow-x-auto pb-4">
+    <section class="mt-8 w-full" v-if="furnitureOffers.length">
+      <h2 class="text-2xl font-semibold mb-4 px-4">Mobilier</h2>
+      <HorizontalScroller>
         <div v-for="item in furnitureOffers" :key="item.id" class="bg-white rounded shadow w-40 flex-shrink-0">
           <img :src="item.image" class="h-24 w-full object-cover rounded-t" />
           <div class="p-2">
@@ -24,10 +24,10 @@
             <p class="text-xs text-gray-500">{{ item.price }}</p>
           </div>
         </div>
-      </div>
+      </HorizontalScroller>
     </section>
 
-    <section class="px-4 mt-8 pb-20">
+    <section class="mt-8 pb-20 w-full">
       <h2 class="text-2xl font-semibold mb-4">Découvrir</h2>
       <div class="grid grid-cols-2 gap-4">
         <div v-for="cat in categories" :key="cat.name" :class="[cat.color, 'rounded p-4 flex items-center text-white space-x-2']">
@@ -41,6 +41,7 @@
 
 <script setup>
 import { ref } from 'vue'
+import HorizontalScroller from '@/components/HorizontalScroller.vue'
 
 const savedOffers = ref([
   { id: 1, title: 'Chaise scandinave', price: '30€', image: 'https://picsum.photos/200/150?random=1' },


### PR DESCRIPTION
## Summary
- add reusable `HorizontalScroller` component
- use `HorizontalScroller` on the home page sections so they fill the page width

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_684fb9ca4c9c8331bf0d48a5dbbabc54