### PR TITLE
Fix annonce form initialization

### DIFF
--- a/pages/annonces.vue
+++ b/pages/annonces.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'annonces'
@@ -64,19 +64,20 @@ function showFlash({ message, type }) {
   }, 3000)
 }
 
-const { data: items, refresh } = await useAsyncData(resource, () => $fetch(`http://localhost:8000/api/${resource}`))
+const { data: items, refresh } = await useAsyncData(
+  resource,
+  () => $fetch(`http://localhost:8000/api/${resource}`)
+)
 
-const fields = ref([])
+// Explicitly define the fields of an annonce so the form is rendered even when
+// the API returns an empty array
+const fields = ref(['titre', 'description', 'prix'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank annonce object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})


### PR DESCRIPTION
## Summary
- fix annonces form so it displays when there are no items

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_684fbfeea6c08331873c6ce9ddbff055