### PR TITLE
Add login landing page with auth guard

### DIFF
--- a/components/BottomNav.vue
+++ b/components/BottomNav.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow flex justify-around items-center py-3 z-10">
-      <NuxtLink to="/" class="flex flex-col items-center">
+      <NuxtLink to="/home" class="flex flex-col items-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75" />
         </svg>
@@ -31,7 +31,7 @@
     <div v-if="open" class="absolute bottom-20 right-4 bg-white border rounded shadow-md p-4 z-20">
       <select class="w-full border px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-400 mb-4" @change="navigate($event)">
         <option disabled selected>Choisir une page</option>
-        <option value="/">Accueil</option>
+        <option value="/home">Accueil</option>
         <option value="/photos">CRUD Photos</option>
         <option value="/annonces">CRUD Annonces</option>
         <option value="/conversations">CRUD Conversations</option>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -1,0 +1,13 @@
+import { computed } from "vue"
+export function useAuth() {
+  const user = useState<any>('user', () => null)
+  const loggedIn = computed(() => !!user.value)
+
+  function logout() {
+    user.value = null
+    navigateTo('/')
+  }
+
+  return { user, loggedIn, logout }
+}
+

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,0 +1,6 @@
+export default defineNuxtRouteMiddleware((to) => {
+  const user = useState<any>('user')
+  if (!user.value && to.path !== '/' && to.path !== '/register') {
+    return navigateTo('/')
+  }
+})

--- a/pages/annonces.vue
+++ b/pages/annonces.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des annonces</h1>
 

--- a/pages/conversations.vue
+++ b/pages/conversations.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des conversations</h1>
 

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -1,0 +1,46 @@
+<!-- pages/home.vue -->
+<template>
+  <div class="min-h-screen bg-gray-50">
+    <section class="mt-8 pb-8 w-full">
+      <h2 class="text-2xl font-semibold mb-4 px-4">Annonces</h2>
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 px-4">
+        <div
+          v-for="annonce in annonces"
+          :key="annonce.id"
+          class="bg-white rounded shadow"
+        >
+          <img :src="annonce.image" class="h-24 w-full object-cover rounded-t" />
+          <div class="p-2">
+            <h3 class="font-medium text-sm truncate">{{ annonce.title }}</h3>
+            <p class="text-xs text-gray-500">{{ annonce.price }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-8 pb-20 w-full">
+      <h2 class="text-2xl font-semibold mb-4">Découvrir</h2>
+      <div class="grid grid-cols-2 gap-4">
+        <div v-for="cat in categories" :key="cat.name" :class="[cat.color, 'rounded p-4 flex items-center text-white space-x-2']">
+          <span class="text-2xl">{{ cat.icon }}</span>
+          <span class="font-medium">{{ cat.name }}</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const { data: annonces } = await useAsyncData('annonces', () =>
+  $fetch('http://localhost:8000/api/annonces')
+)
+
+const categories = ref([
+  { name: 'Outils', color: 'bg-blue-600', icon: '🛠️' },
+  { name: 'Sport', color: 'bg-green-600', icon: '⚽' },
+  { name: 'Électronique', color: 'bg-yellow-500', icon: '💻' },
+  { name: 'Jeux', color: 'bg-red-500', icon: '🎲' },
+])
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,46 +1,33 @@
-<!-- pages/index.vue -->
 <template>
-  <div class="min-h-screen bg-gray-50">
-    <section class="mt-8 pb-8 w-full">
-      <h2 class="text-2xl font-semibold mb-4 px-4">Annonces</h2>
-      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 px-4">
-        <div
-          v-for="annonce in annonces"
-          :key="annonce.id"
-          class="bg-white rounded shadow"
-        >
-          <img :src="annonce.image" class="h-24 w-full object-cover rounded-t" />
-          <div class="p-2">
-            <h3 class="font-medium text-sm truncate">{{ annonce.title }}</h3>
-            <p class="text-xs text-gray-500">{{ annonce.price }}</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="mt-8 pb-20 w-full">
-      <h2 class="text-2xl font-semibold mb-4">Découvrir</h2>
-      <div class="grid grid-cols-2 gap-4">
-        <div v-for="cat in categories" :key="cat.name" :class="[cat.color, 'rounded p-4 flex items-center text-white space-x-2']">
-          <span class="text-2xl">{{ cat.icon }}</span>
-          <span class="font-medium">{{ cat.name }}</span>
-        </div>
-      </div>
-    </section>
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <form class="bg-white p-6 rounded shadow w-80 space-y-4" @submit.prevent="loginUser">
+      <h1 class="text-2xl font-bold text-center mb-4">Connexion</h1>
+      <input v-model="email" type="email" placeholder="Email" class="w-full border px-4 py-2 rounded" />
+      <input v-model="password" type="password" placeholder="Mot de passe" class="w-full border px-4 py-2 rounded" />
+      <button type="submit" class="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">Se connecter</button>
+      <NuxtLink to="/register" class="block text-center text-blue-600 hover:underline">Créer un compte</NuxtLink>
+    </form>
+    <AppToast v-if="error" :message="error" type="error" />
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppToast from '@/components/AppToast.vue'
 
-const { data: annonces } = await useAsyncData('annonces', () =>
-  $fetch('http://localhost:8000/api/annonces')
-)
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const router = useRouter()
 
-const categories = ref([
-  { name: 'Outils', color: 'bg-blue-600', icon: '🛠️' },
-  { name: 'Sport', color: 'bg-green-600', icon: '⚽' },
-  { name: 'Électronique', color: 'bg-yellow-500', icon: '💻' },
-  { name: 'Jeux', color: 'bg-red-500', icon: '🎲' },
-])
+function loginUser() {
+  if (email.value && password.value) {
+    const userState = useState('user')
+    userState.value = { email: email.value }
+    router.push('/home')
+  } else {
+    error.value = 'Email et mot de passe requis'
+  }
+}
 </script>

--- a/pages/messages.vue
+++ b/pages/messages.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des messages</h1>
 

--- a/pages/photos.vue
+++ b/pages/photos.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📸 Gestion des photos</h1>
 

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <form class="bg-white p-6 rounded shadow w-80 space-y-4" @submit.prevent="createAccount">
+      <h1 class="text-2xl font-bold text-center mb-4">Inscription</h1>
+      <input v-model="email" type="email" placeholder="Email" class="w-full border px-4 py-2 rounded" />
+      <input v-model="password" type="password" placeholder="Mot de passe" class="w-full border px-4 py-2 rounded" />
+      <button type="submit" class="bg-green-600 text-white w-full py-2 rounded hover:bg-green-700">S'inscrire</button>
+      <NuxtLink to="/" class="block text-center text-blue-600 hover:underline">Déjà un compte ? Connexion</NuxtLink>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const email = ref('')
+const password = ref('')
+const router = useRouter()
+
+function createAccount() {
+  if (email.value && password.value) {
+    router.push('/')
+  }
+}
+</script>

--- a/pages/reservations.vue
+++ b/pages/reservations.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des reservations</h1>
 

--- a/pages/users.vue
+++ b/pages/users.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des users</h1>
 

--- a/pages/utilisateur-conversations.vue
+++ b/pages/utilisateur-conversations.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des utilisateur-conversations</h1>
 

--- a/pages/utilisateurs.vue
+++ b/pages/utilisateurs.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 py-10 px-4">
-    <NuxtLink to="/" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
+    <NuxtLink to="/home" class="inline-block mb-6 text-blue-600 hover:underline font-semibold"> ← Retour à l'accueil </NuxtLink>
     <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-blue-600 mb-6">📄 Gestion des utilisateurs</h1>
 


### PR DESCRIPTION
## Summary
- move home content to `/home`
- create login and register pages
- add global middleware to guard routes
- add `useAuth` composable
- update navigation links for new home path

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68502e70cd4c8331977b1ef30007632d