### PR TITLE
Add flash system and auth layout

### DIFF
--- a/composables/useFlash.ts
+++ b/composables/useFlash.ts
@@ -1,0 +1,15 @@
+export type FlashMessage = { message: string; type: 'success' | 'error' }
+
+export function useFlash() {
+  const flash = useState<FlashMessage | null>('flash', () => null)
+
+  function setFlash(message: string, type: 'success' | 'error' = 'success') {
+    flash.value = { message, type }
+  }
+
+  function clearFlash() {
+    flash.value = null
+  }
+
+  return { flash, setFlash, clearFlash }
+}

--- a/layouts/auth.vue
+++ b/layouts/auth.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<script setup>
+// Empty layout without navigation
+</script>

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,6 +1,8 @@
 export default defineNuxtRouteMiddleware((to) => {
   const user = useState<any>('user')
   if (!user.value && to.path !== '/' && to.path !== '/register') {
+    const flash = useState<any>('flash')
+    flash.value = { message: 'Vous devez être connecté pour accéder à cette page', type: 'error' }
     return navigateTo('/')
   }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,14 +12,26 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import AppToast from '@/components/AppToast.vue'
+
+definePageMeta({
+  layout: 'auth',
+})
 
 const email = ref('')
 const password = ref('')
 const error = ref('')
 const router = useRouter()
+const flash = useState<any>('flash', () => null)
+
+onMounted(() => {
+  if (flash.value) {
+    error.value = flash.value.message
+    flash.value = null
+  }
+})
 
 function loginUser() {
   if (email.value && password.value) {

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -14,6 +14,10 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 
+definePageMeta({
+  layout: 'auth',
+})
+
 const email = ref('')
 const password = ref('')
 const router = useRouter()


### PR DESCRIPTION
## Summary
- create `auth` layout without bottom navigation
- add flash composable
- show flash when unauthenticated via middleware
- display flash on login page
- use auth layout for login & register pages

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_685030f8e9c483318c1dc8d2463fb0bb