### PR TITLE
Connect front auth forms to backend

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,6 +15,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import AppToast from '@/components/AppToast.vue'
+import { apiFetch } from '@/composables/useApi'
 
 definePageMeta({
   layout: 'auth',
@@ -33,13 +34,22 @@ onMounted(() => {
   }
 })
 
-function loginUser() {
-  if (email.value && password.value) {
-    const userState = useState('user')
-    userState.value = { email: email.value }
-    router.push('/home')
-  } else {
+async function loginUser() {
+  error.value = ''
+  if (!email.value || !password.value) {
     error.value = 'Email et mot de passe requis'
+    return
+  }
+  try {
+    const data = await apiFetch<any>('/login', {
+      method: 'POST',
+      body: { email: email.value, password: password.value },
+    })
+    const userState = useState('user')
+    userState.value = data
+    router.push('/home')
+  } catch (e: any) {
+    error.value = e?.data?.message || 'Erreur lors de la connexion'
   }
 }
 </script>

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -7,12 +7,16 @@
       <button type="submit" class="bg-green-600 text-white w-full py-2 rounded hover:bg-green-700">S'inscrire</button>
       <NuxtLink to="/" class="block text-center text-blue-600 hover:underline">Déjà un compte ? Connexion</NuxtLink>
     </form>
+    <AppToast v-if="error" :message="error" type="error" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import AppToast from '@/components/AppToast.vue'
+import { apiFetch } from '@/composables/useApi'
+import { useFlash } from '@/composables/useFlash'
 
 definePageMeta({
   layout: 'auth',
@@ -20,11 +24,25 @@ definePageMeta({
 
 const email = ref('')
 const password = ref('')
+const error = ref('')
 const router = useRouter()
+const { setFlash } = useFlash()
 
-function createAccount() {
-  if (email.value && password.value) {
+async function createAccount() {
+  error.value = ''
+  if (!email.value || !password.value) {
+    error.value = 'Email et mot de passe requis'
+    return
+  }
+  try {
+    await apiFetch('/register', {
+      method: 'POST',
+      body: { email: email.value, password: password.value },
+    })
+    setFlash('Compte créé, connectez-vous', 'success')
     router.push('/')
+  } catch (e: any) {
+    error.value = e?.data?.message || "Erreur lors de l'inscription"
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- call API endpoints for login
- wire up registration to API and show errors

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68503307b8d88331a65d96995c1a9fe3