### PR TITLE
Improve CRUD menu in bottom nav

### DIFF
--- a/components/BottomNav.vue
+++ b/components/BottomNav.vue
@@ -3,7 +3,11 @@
     <nav class="fixed bottom-0 left-0 right-0 bg-white border-t shadow flex justify-around items-center py-3 z-10">
       <NuxtLink to="/home" class="flex flex-col items-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75"
+          />
         </svg>
       </NuxtLink>
       <NuxtLink to="/annonces" class="flex flex-col items-center">
@@ -16,37 +20,34 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 103.404 3.404a7.5 7.5 0 0012.399 12.399z" />
         </svg>
       </NuxtLink>
-      <button @click="toggle" class="flex flex-col items-center">
+      <button @click="toggle" :aria-label="open ? 'Fermer le menu' : 'Ouvrir le menu'" class="flex flex-col items-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>
       </button>
       <NuxtLink to="/profile" class="flex flex-col items-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 1115 0v.75H4.5v-.75z" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 1115 0v.75H4.5v-.75z"
+          />
         </svg>
       </NuxtLink>
     </nav>
     <div v-if="open" class="fixed inset-0 z-0" @click="open = false"></div>
     <div v-if="open" class="absolute bottom-20 right-4 bg-white border rounded shadow-md p-4 z-20">
-      <select class="w-full border px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-400 mb-4" @change="navigate($event)">
-        <option disabled selected>Choisir une page</option>
-        <option value="/home">Accueil</option>
-        <option value="/photos">CRUD Photos</option>
-        <option value="/annonces">CRUD Annonces</option>
-        <option value="/conversations">CRUD Conversations</option>
-        <option value="/messages">CRUD Messages</option>
-        <option value="/reservations">CRUD Reservations</option>
-        <option value="/utilisateurs">CRUD Utilisateurs</option>
-        <option value="/utilisateur-conversations">CRUD Utilisateur-Conversations</option>
-        <option value="/users">CRUD Users</option>
-      </select>
+      <ul class="space-y-2 mb-2">
+        <li v-for="link in crudLinks" :key="link.to">
+          <NuxtLink :to="link.to" class="block" :aria-label="link.label" @click="closeMenu">{{ link.label }}</NuxtLink>
+        </li>
+      </ul>
       <ul class="space-y-2">
         <li>
-          <NuxtLink to="/favorites" class="block">Mes favoris</NuxtLink>
+          <NuxtLink to="/favorites" class="block" aria-label="Mes favoris" @click="closeMenu">Mes favoris</NuxtLink>
         </li>
         <li>
-          <NuxtLink to="/reservations" class="block">Mes reservations</NuxtLink>
+          <NuxtLink to="/reservations" class="block" aria-label="Mes reservations" @click="closeMenu">Mes reservations</NuxtLink>
         </li>
       </ul>
     </div>
@@ -55,20 +56,24 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
 
 const open = ref(false)
-const router = useRouter()
+const crudLinks = [
+  { to: '/home', label: 'Accueil' },
+  { to: '/photos', label: 'CRUD Photos' },
+  { to: '/annonces', label: 'CRUD Annonces' },
+  { to: '/conversations', label: 'CRUD Conversations' },
+  { to: '/messages', label: 'CRUD Messages' },
+  { to: '/reservations', label: 'CRUD Reservations' },
+  { to: '/utilisateurs', label: 'CRUD Utilisateurs' },
+  { to: '/utilisateur-conversations', label: 'CRUD Utilisateur-Conversations' },
+  { to: '/users', label: 'CRUD Users' },
+]
 function toggle() {
   open.value = !open.value
 }
 
-function navigate(event: Event) {
-  const target = event.target as HTMLSelectElement
-  const value = target.value
-  if (value) {
-    router.push(value)
-    open.value = false
-  }
+function closeMenu() {
+  open.value = false
 }
 </script>


### PR DESCRIPTION
## Summary
- switch drop-down to vertical CRUD link list
- close menu automatically after navigation
- add labels for accessibility

## Testing
- `npx prettier --write components/BottomNav.vue`
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68517632d1e48331988119018e7105bc