### PR TITLE
Refactor CRUD pages for static fields

### DIFF
--- a/pages/conversations.vue
+++ b/pages/conversations.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'conversations'
@@ -66,17 +66,14 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicit fields so the form exists even with no API data
+const fields = ref(['titre', 'utilisateurId'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank conversation object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})

--- a/pages/messages.vue
+++ b/pages/messages.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'messages'
@@ -66,17 +66,15 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicitly define the fields so the form is rendered even when the API
+// returns an empty array
+const fields = ref(['contenu', 'utilisateurId', 'conversationId'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank message object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})

--- a/pages/reservations.vue
+++ b/pages/reservations.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'reservations'
@@ -66,17 +66,14 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicit fields to allow form rendering without existing data
+const fields = ref(['annonceId', 'utilisateurId', 'dateDebut', 'dateFin'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank reservation object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})

--- a/pages/users.vue
+++ b/pages/users.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'users'
@@ -66,17 +66,14 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicit fields to ensure the form renders without data
+const fields = ref(['email', 'password'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank user object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})

--- a/pages/utilisateur-conversations.vue
+++ b/pages/utilisateur-conversations.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'utilisateur-conversations'
@@ -66,17 +66,14 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicit fields to render form without API data
+const fields = ref(['utilisateurId', 'conversationId'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank utilisateur-conversation object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})

--- a/pages/utilisateurs.vue
+++ b/pages/utilisateurs.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect } from 'vue'
+import { ref } from 'vue'
 import AppToast from '@/components/AppToast.vue'
 
 const resource = 'utilisateurs'
@@ -66,17 +66,14 @@ function showFlash({ message, type }) {
 
 const { data: items, refresh } = await useAsyncData(resource, () => apiFetch(`/${resource}`))
 
-const fields = ref([])
+// Explicitly list fields so the form renders even with an empty API response
+const fields = ref(['nom', 'email', 'password'])
 const newItem = ref({})
 const editingId = ref(null)
 const editItem = ref({})
 
-watchEffect(() => {
-  if (items.value?.length && fields.value.length === 0) {
-    fields.value = Object.keys(items.value[0]).filter((k) => k !== 'id')
-    resetNewItem()
-  }
-})
+// Initialize a blank utilisateur object when the component is created
+resetNewItem()
 
 function resetNewItem() {
   newItem.value = fields.value.reduce((acc, f) => ({ ...acc, [f]: '' }), {})


### PR DESCRIPTION
## Summary
- remove `watchEffect` and define constant field arrays in CRUD pages
- initialize forms using these fields so they render even with empty API data

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_6851763add948331a84be40cf5df3cf0