### PR TITLE
Expose API URL via runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,11 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## API configuration
+
+The application uses the Nuxt runtime config variable `API_BASE_URL` to
+determine the backend API URL. By default it points to
+`http://localhost:8000/api`. Set the environment variable `API_BASE_URL`
+locally if you need to override this value.
 # ESGI-front

--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -1,4 +1,4 @@
-export const baseURL = 'http://localhost:8000/api'
+export const baseURL = useRuntimeConfig().public.API_BASE_URL
 
 export function apiFetch<T>(path: string, options?: Parameters<typeof $fetch<T>>[1]) {
   return $fetch<T>(`${baseURL}${path}`, options)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,4 +9,9 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   modules: ['@nuxt/eslint'],
+  runtimeConfig: {
+    public: {
+      API_BASE_URL: process.env.API_BASE_URL || 'http://localhost:8000/api',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- load API base URL from Nuxt runtime config
- configure `API_BASE_URL` in `nuxt.config.ts`
- document API base URL override in README

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68517642f6cc83319a766da806e28b60