### PR TITLE
Update toast positioning

### DIFF
--- a/components/AppToast.vue
+++ b/components/AppToast.vue
@@ -1,7 +1,13 @@
 <!-- components/AppToast.vue -->
 <template>
   <transition name="fade">
-    <div v-if="visible" :class="['fixed bottom-4 right-4 px-4 py-2 rounded shadow-lg text-white', type === 'success' ? 'bg-green-500' : 'bg-red-500']">
+    <div
+      v-if="visible"
+      :class="[
+        'fixed bottom-16 right-4 z-20 px-4 py-2 rounded shadow-lg text-white',
+        type === 'success' ? 'bg-green-500' : 'bg-red-500'
+      ]"
+    >
       {{ message }}
     </div>
   </transition>


### PR DESCRIPTION
## Summary
- ensure toast appears above the bottom navbar with `z-20`
- move toast higher using `bottom-16`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68517b29d5a48331843c9e595c304cd5