### PR TITLE
Use apiFetch in home page

### DIFF
--- a/pages/home.vue
+++ b/pages/home.vue
@@ -28,8 +28,9 @@
 
 <script setup>
 import { ref } from 'vue'
+import { apiFetch } from '@/composables/useApi'
 
-const { data: annonces } = await useAsyncData('annonces', () => $fetch('http://localhost:8000/api/annonces'))
+const { data: annonces } = await useAsyncData('annonces', () => apiFetch('/annonces'))
 
 const categories = ref([
   { name: 'Outils', color: 'bg-blue-600', icon: '🛠️' },


### PR DESCRIPTION
## Summary
- call apiFetch from the home page instead of a hardcoded URL

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68517b3426dc8331927c34e226eaf4cf