### PR TITLE
Add Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,25 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './app.vue',
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          light: '#3a7ca5',
+          DEFAULT: '#2a4d69',
+          dark: '#1e3750',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- configure Tailwind via `tailwind.config.js`

## Testing
- `npm run build` *(fails: nuxt not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68517bfe801c83318b84d486777aee07