### PR TITLE
Add reusable FormInput component

### DIFF
--- a/components/FormInput.vue
+++ b/components/FormInput.vue
@@ -1,0 +1,30 @@
+<template>
+  <label class="block space-y-1">
+    <span class="text-sm text-gray-700">{{ placeholder }}</span>
+    <input
+      :type="type"
+      :placeholder="placeholder"
+      class="w-full border px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
+      :value="modelValue"
+      @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+  </label>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  type: {
+    type: String,
+    default: 'text',
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+})
+</script>
+

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,8 +2,8 @@
   <div class="min-h-screen flex items-center justify-center bg-gray-50">
     <form class="bg-white p-6 rounded shadow w-80 space-y-4" @submit.prevent="loginUser">
       <h1 class="text-2xl font-bold text-center mb-4">Connexion</h1>
-      <input v-model="email" type="email" placeholder="Email" class="w-full border px-4 py-2 rounded" />
-      <input v-model="password" type="password" placeholder="Mot de passe" class="w-full border px-4 py-2 rounded" />
+      <FormInput v-model="email" type="email" placeholder="Email" />
+      <FormInput v-model="password" type="password" placeholder="Mot de passe" />
       <button type="submit" class="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">Se connecter</button>
       <NuxtLink to="/register" class="block text-center text-blue-600 hover:underline">Créer un compte</NuxtLink>
     </form>
@@ -15,6 +15,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import AppToast from '@/components/AppToast.vue'
+import FormInput from '@/components/FormInput.vue'
 import { apiFetch } from '@/composables/useApi'
 
 definePageMeta({

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -2,8 +2,8 @@
   <div class="min-h-screen flex items-center justify-center bg-gray-50">
     <form class="bg-white p-6 rounded shadow w-80 space-y-4" @submit.prevent="createAccount">
       <h1 class="text-2xl font-bold text-center mb-4">Inscription</h1>
-      <input v-model="email" type="email" placeholder="Email" class="w-full border px-4 py-2 rounded" />
-      <input v-model="password" type="password" placeholder="Mot de passe" class="w-full border px-4 py-2 rounded" />
+      <FormInput v-model="email" type="email" placeholder="Email" />
+      <FormInput v-model="password" type="password" placeholder="Mot de passe" />
       <button type="submit" class="bg-green-600 text-white w-full py-2 rounded hover:bg-green-700">S'inscrire</button>
       <NuxtLink to="/" class="block text-center text-blue-600 hover:underline">Déjà un compte ? Connexion</NuxtLink>
     </form>
@@ -15,6 +15,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import AppToast from '@/components/AppToast.vue'
+import FormInput from '@/components/FormInput.vue'
 import { apiFetch } from '@/composables/useApi'
 import { useFlash } from '@/composables/useFlash'
 


### PR DESCRIPTION
## Summary
- create `FormInput.vue` for common input/label styling
- refactor login and register pages to use `<FormInput>`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_68517c00c7dc83318fce105c5cf212f2