### PR TITLE
Add auth persistence via cookie

### DIFF
--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -5,6 +5,8 @@ export function useAuth() {
 
   function logout() {
     user.value = null
+    const token = useCookie<any>('user_token')
+    token.value = null
     navigateTo('/')
   }
 

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,5 +1,11 @@
 export default defineNuxtRouteMiddleware((to) => {
   const user = useState<any>('user')
+  if (!user.value) {
+    const token = useCookie<any>('user_token')
+    if (token.value) {
+      user.value = token.value
+    }
+  }
   if (!user.value && to.path !== '/' && to.path !== '/register') {
     const flash = useState<any>('flash')
     flash.value = { message: 'Vous devez être connecté pour accéder à cette page', type: 'error' }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,6 +48,8 @@ async function loginUser() {
     })
     const userState = useState('user')
     userState.value = data
+    const token = useCookie<any>('user_token')
+    token.value = data
     router.push('/home')
   } catch (e: any) {
     error.value = e?.data?.message || 'Erreur lors de la connexion'

--- a/plugins/auth.client.ts
+++ b/plugins/auth.client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(() => {
+  const user = useState<any>('user', () => null)
+  const token = useCookie<any>('user_token', { default: () => null })
+  if (!user.value && token.value) {
+    user.value = token.value
+  }
+})


### PR DESCRIPTION
## Summary
- create a client plugin to restore user from cookie
- store token after login
- clear cookie on logout
- check cookie inside auth middleware

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*

------
https://chatgpt.com/codex/tasks/task_e_685183ce431c8331bde513c3b7586429